### PR TITLE
Allow multiple sections

### DIFF
--- a/crypto/cmp/cmp_lib.c
+++ b/crypto/cmp/cmp_lib.c
@@ -1433,7 +1433,6 @@ static X509 *CMP_CERTORENCCERT_encCert_get1(CMP_CERTORENCCERT *coec,
                    CMP_R_ERROR_DECRYPTING_SYMMETRIC_KEY);
             goto err;
         }
-        EVP_PKEY_CTX_free(pkctx);
     } else {
         CMPerr(CMP_F_CMP_CERTORENCCERT_ENCCERT_GET1,
                CMP_R_ERROR_DECRYPTING_KEY);
@@ -1481,6 +1480,7 @@ static X509 *CMP_CERTORENCCERT_encCert_get1(CMP_CERTORENCCERT *coec,
         goto err;
     }
 
+    EVP_PKEY_CTX_free(pkctx);
     OPENSSL_free(outbuf);
     EVP_CIPHER_CTX_free(evp_ctx);
     OPENSSL_free(ek);
@@ -1489,14 +1489,11 @@ static X509 *CMP_CERTORENCCERT_encCert_get1(CMP_CERTORENCCERT *coec,
  err:
     CMPerr(CMP_F_CMP_CERTORENCCERT_ENCCERT_GET1,
            CMP_R_ERROR_DECRYPTING_ENCCERT);
-    if (outbuf)
-        OPENSSL_free(outbuf);
-    if (evp_ctx)
-        EVP_CIPHER_CTX_free(evp_ctx);
-    if (ek)
-        OPENSSL_free(ek);
-    if (iv)
-        OPENSSL_free(iv);
+    EVP_PKEY_CTX_free(pkctx);
+    OPENSSL_free(outbuf);
+    EVP_CIPHER_CTX_free(evp_ctx);
+    OPENSSL_free(ek);
+    OPENSSL_free(iv);
     return NULL;
 }
 

--- a/doc/man1/cmp.pod
+++ b/doc/man1/cmp.pod
@@ -9,7 +9,7 @@ cmp - client for the Certificate Management Protocol (RFC4210)
 B<openssl> B<cmp>
 S<[B<-help>]>
 S<[B<-config filename>]>
-S<[B<-section name>]>
+S<[B<-section names>]>
 
 S<[B<-server address:port>]>
 S<[B<-proxy address:port>]>
@@ -140,12 +140,14 @@ Display a summary of all options
 Configuration file to use. An empty string C<""> means none.
 Default file name is taken from the environment variable C<OPENSSL_CONF>.
 
-=item B<-section name>
+=item B<-section names>
 
-Section to use within config file defining CMP options,
+Section(s) to use within config file defining CMP options.
 An empty string C<""> means no specific section. Default is C<cmp>.
-In any case, as usual, the S<C<[default]>> section and finally the unnamed section
-(as far as present) can provide per-option fallback values.
+Multiple section names may be given, separated by commas or whitespace.
+Contents of sections named later may override contents of sections named before.
+In any case, as usual, the S<C<[default]>> section and finally the unnamed
+section (as far as present) can provide per-option fallback values.
 
 =back
 


### PR DESCRIPTION
Allows to use multiple config file sections in the cmp cli.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
