### PR TITLE
correctly support OPENSSL_NO_CMP (config option no-cmp)

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -75,7 +75,7 @@ static ENGINE *try_load_engine(const char *engine)
 }
 #endif
 
-#if !defined(OPENSSL_NO_UI_CONSOLE) || !defined(OPENSSL_NO_ENGINE)
+#ifndef OPENSSL_NO_ENGINE
 static UI_METHOD *ui_method = NULL;
 #endif
 
@@ -235,9 +235,7 @@ static char *opt_otherform_s = "PEM";
 static int opt_otherform = FORMAT_PEM;
 static char *opt_otherpass = NULL;
 static int opt_batch = 0;
-#ifndef OPENSSL_NO_ENGINE
 static char *opt_engine = NULL;
-#endif
 
 static char *opt_newkey = NULL;
 static char *opt_newkeypass = NULL;
@@ -4395,13 +4393,15 @@ int cmp_main(int argc, char **argv)
     ret = 1;
 
     if (opt_batch) {
+#ifndef OPENSSL_NO_ENGINE
         UI_METHOD *ui_fallback_method;
-#ifndef OPENSSL_NO_UI_CONSOLE
+# ifndef OPENSSL_NO_UI_CONSOLE
         ui_fallback_method = UI_OpenSSL();
-#else
-        ui_fallback_method = UI_null();
-#endif
+# else
+        ui_fallback_method = (UI_METHOD *)UI_null();
+# endif
         UI_method_set_reader(ui_fallback_method, NULL);
+#endif
     }
 
     if (opt_engine)

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -11,10 +11,6 @@
  * CMP implementation by Martin Peylo, Miikka Viljanen, and David von Oheimb.
  */
 
-#include <openssl/opensslconf.h>
-#include <openssl/pkcs12.h>
-#include <openssl/ssl.h>
-
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -23,6 +19,12 @@
 #include "progs.h"
 #endif
 #include "s_apps.h"
+
+#ifndef OPENSSL_NO_CMP
+
+#include <openssl/opensslconf.h>
+#include <openssl/pkcs12.h>
+#include <openssl/ssl.h>
 
 #if OPENSSL_VERSION_NUMBER < 0x1010001fL
 # define X509_STORE_CTX_set0_verified_chain(ctx, sk) { \
@@ -4523,3 +4525,5 @@ int cmp_main(int argc, char **argv)
 
     return ret > 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }
+
+#endif

--- a/include/openssl/cmp.h
+++ b/include/openssl/cmp.h
@@ -20,6 +20,7 @@
 # include <openssl/x509.h>
 # include <openssl/x509v3.h>
 # include <openssl/safestack.h>
+# ifndef OPENSSL_NO_CMP
 # if OPENSSL_VERSION_NUMBER >= 0x10101000L
 #  include <openssl/cmperr.h>
 # endif
@@ -606,6 +607,7 @@ int i2d_CMP_PKIMESSAGE(CMP_PKIMESSAGE *, unsigned char **);
 
 # ifdef  __cplusplus
 }
+#  endif
 # endif
 #endif /* fndef HEADER_CMP_H */
 

--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -13,6 +13,8 @@
 
 #include "cmptestlib.h"
 
+#ifndef OPENSSL_NO_CMP
+
 typedef struct test_fixture {
     const char *test_case_name;
     X509_EXTENSIONS *exts;
@@ -83,14 +85,17 @@ static int test_cmp_ctx_reqextensions_have_san(void)
     return result;
 }
 
-int setup_tests(void)
-{
-    ADD_TEST(test_cmp_ctx_reqextensions_have_san);
-
-    return 1;
-}
-
 void cleanup_tests(void)
 {
     return;
+}
+#endif
+
+int setup_tests(void)
+{
+#ifndef OPENSSL_NO_CMP
+    ADD_TEST(test_cmp_ctx_reqextensions_have_san);
+#endif
+
+    return 1;
 }

--- a/test/cmp_internal_test.c
+++ b/test/cmp_internal_test.c
@@ -12,7 +12,10 @@
  */
 
 #include "cmptestlib.h"
-#include <crypto/cmp/cmp_int.h>
+
+#ifndef OPENSSL_NO_CMP
+
+# include <crypto/cmp/cmp_int.h>
 
 /* Add test code as per
  * http://wiki.openssl.org/index.php/How_To_Write_Unit_Tests_For_OpenSSL#Style
@@ -257,8 +260,16 @@ static int test_cmp_pkiheader_init_no_ref_no_subject(void)
     return result;
 }
 
+void cleanup_tests(void)
+{
+    EVP_PKEY_free(loadedprivkey);
+    EVP_PKEY_free(loadedpubkey);
+}
+#endif
+
 int setup_tests(void)
 {
+#ifndef OPENSSL_NO_CMP
     if (!TEST_ptr(loadedprivkey = load_pem_key("../cmp-test/server.pem")))
         return 0;
     if (TEST_true(EVP_PKEY_up_ref(loadedprivkey)))
@@ -272,11 +283,7 @@ int setup_tests(void)
     ADD_TEST(test_cmp_pkiheader_init);
     ADD_TEST(test_cmp_pkiheader_init_with_subject);
     ADD_TEST(test_cmp_pkiheader_init_no_ref_no_subject);
-    return 1;
-}
+#endif
 
-void cleanup_tests(void)
-{
-    EVP_PKEY_free(loadedprivkey);
-    EVP_PKEY_free(loadedpubkey);
+    return 1;
 }

--- a/test/cmp_lib_test.c
+++ b/test/cmp_lib_test.c
@@ -13,6 +13,8 @@
 
 #include "cmptestlib.h"
 
+#ifndef OPENSSL_NO_CMP
+
 typedef struct test_fixture {
     const char *test_case_name;
     int expected;
@@ -607,8 +609,26 @@ static int test_cmp_x509_store_only_self_signed(void)
     return result;
 }
 
+
+void cleanup_tests(void)
+{
+    EVP_PKEY_free(loadedkey);
+    X509_free(cert);
+    X509_free(endentity1);
+    X509_free(endentity2);
+    X509_free(root);
+    X509_free(intermediate);
+    CMP_PKIMESSAGE_free(ir_protected);
+    CMP_PKIMESSAGE_free(ir_unprotected);
+    CMP_PKIMESSAGE_free(insta_unprotected);
+
+    return;
+}
+#endif
+
 int setup_tests(void)
 {
+#ifndef OPENSSL_NO_CMP
     if(!TEST_int_eq(1, RAND_bytes(rand_data, TRANSACTIONID_LENGTH)))
         return 0;
     if (!TEST_ptr(endentity1 =
@@ -658,20 +678,7 @@ int setup_tests(void)
     ADD_TEST(test_cmp_x509_store_only_self_signed);
     /* TODO make sure that total number of tests (here currently 24) is shown,
      also for other cmp_*text.c. Currently the test drivers always show 1. */
+
+#endif
     return 1;
-}
-
-void cleanup_tests(void)
-{
-    EVP_PKEY_free(loadedkey);
-    X509_free(cert);
-    X509_free(endentity1);
-    X509_free(endentity2);
-    X509_free(root);
-    X509_free(intermediate);
-    CMP_PKIMESSAGE_free(ir_protected);
-    CMP_PKIMESSAGE_free(ir_unprotected);
-    CMP_PKIMESSAGE_free(insta_unprotected);
-
-    return;
 }

--- a/test/cmp_msg_test.c
+++ b/test/cmp_msg_test.c
@@ -13,6 +13,8 @@
 
 #include "cmptestlib.h"
 
+#ifndef OPENSSL_NO_CMP
+
 typedef struct test_fixture {
     const char *test_case_name;
     CMP_CTX *cmp_ctx;
@@ -410,9 +412,16 @@ static int test_cmp_pkimessage_create(int bodytype)
     return result;
 }
 
+void cleanup_tests(void)
+{
+    EVP_PKEY_free(newkey);
+    X509_free(cert);
+}
+#endif
+
 int setup_tests(void)
 {
-
+#ifndef OPENSSL_NO_CMP
     if (!TEST_ptr(newkey = gen_rsa()) ||
         !TEST_ptr(cert =
                   load_pem_cert("../cmp-test/openssl_cmp_test_server.crt")) ||
@@ -439,12 +448,7 @@ int setup_tests(void)
     ADD_TEST(test_cmp_create_genm);
     ADD_ALL_TESTS_NOSUBTEST(test_cmp_pkimessage_create,
                             V_CMP_PKIBODY_POLLREP + 1);
+#endif
 
     return 1;
-}
-
-void cleanup_tests(void)
-{
-    EVP_PKEY_free(newkey);
-    X509_free(cert);
 }

--- a/test/cmp_ses_test.c
+++ b/test/cmp_ses_test.c
@@ -13,8 +13,8 @@
 
 #include "cmptestlib.h"
 
-#ifndef NDEBUG  /* tests need mock server, which is available only if !NDEBUG */
-
+#ifndef OPENSSL_NO_CMP
+# ifndef NDEBUG /* tests need mock server, which is available only if !NDEBUG */
 
 typedef struct test_fixture {
     const char *test_case_name;
@@ -307,12 +307,19 @@ int setup_tests(void)
     return 1;
 }
 
-#else  /* !defined (NDEBUG) */
+# else /* !defined (NDEBUG) */
 
 int setup_tests(void)
 {
-    TEST_note("CMP session tests are disabled in this build.");
+    TEST_note("CMP session tests are disabled in this build (NDEBUG).");
     return 1;
 }
 
+# endif
+
+#else /* !defined (OPENSSL_NO_CMP) */
+int setup_tests(void)
+{
+    return 1;
+}
 #endif

--- a/test/cmp_vfy_test.c
+++ b/test/cmp_vfy_test.c
@@ -13,6 +13,8 @@
 
 #include "cmptestlib.h"
 
+#ifndef OPENSSL_NO_CMP
+
 typedef struct test_fixture {
     const char *test_case_name;
     int expected;
@@ -266,8 +268,21 @@ static int test_cmp_validate_cert_path_expired(void)
     return result;
 }
 
+void cleanup_tests(void)
+{
+    X509_free(srvcert);
+    X509_free(clcert);
+    X509_free(endentity1);
+    X509_free(endentity2);
+    X509_free(intermediate);
+    X509_free(root);
+    return;
+}
+#endif
+
 int setup_tests(void)
 {
+#ifndef OPENSSL_NO_CMP
     /* Set test time stamps */
     struct tm ts = { 0 };
     ts.tm_year = 2018 - 1900;
@@ -307,16 +322,7 @@ int setup_tests(void)
     ADD_TEST(test_cmp_validate_cert_path);
     ADD_TEST(test_cmp_validate_cert_path_expired);
     ADD_TEST(test_cmp_validate_cert_path_no_anchor);
-    return 1;
-}
+#endif
 
-void cleanup_tests(void)
-{
-    X509_free(srvcert);
-    X509_free(clcert);
-    X509_free(endentity1);
-    X509_free(endentity2);
-    X509_free(intermediate);
-    X509_free(root);
-    return;
+    return 1;
 }

--- a/test/cmptestlib.c
+++ b/test/cmptestlib.c
@@ -13,6 +13,8 @@
 
 #include "cmptestlib.h"
 
+#ifndef OPENSSL_NO_CMP
+
 EVP_PKEY *load_pem_key(const char *file)
 {
     EVP_PKEY *key = NULL;
@@ -132,3 +134,5 @@ int STACK_OF_X509_push1(STACK_OF(X509) *sk, X509 *cert)
         X509_free(cert); /* down-ref */
     return res;
 }
+
+#endif

--- a/test/cmptestlib.h
+++ b/test/cmptestlib.h
@@ -19,7 +19,8 @@
 # include <openssl/rand.h>
 # include "testutil.h"
 
-# define TEST_CMP_REFVALUE_LENGTH 15 /* arbitary value */
+# ifndef OPENSSL_NO_CMP
+#  define TEST_CMP_REFVALUE_LENGTH 15 /* arbitary value */
 EVP_PKEY *load_pem_key(const char *file);
 X509 *load_pem_cert(const char *file);
 X509_REQ *load_csr(const char *file);
@@ -28,5 +29,6 @@ int valid_asn1_encoding(const CMP_PKIMESSAGE *msg);
 EVP_PKEY *gen_rsa(void);
 int STACK_OF_X509_cmp(const STACK_OF(X509) *sk1, const STACK_OF(X509) *sk2);
 int STACK_OF_X509_push1(STACK_OF(X509) *sk, X509 *cert);
+# endif
 
 #endif /* HEADER_CMP_TEST_LIB_H */


### PR DESCRIPTION
fixes #126 

- [x] tests are added or updated
