### PR TITLE
Including non-successfully verified protection to be covered by -unprotectederrors

### DIFF
--- a/crypto/cmp/cmp_lib.c
+++ b/crypto/cmp/cmp_lib.c
@@ -1724,22 +1724,18 @@ int OSSL_CMP_MSG_check_received(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
         return -1;
 
     /* validate message protection */
-    if (msg->header->protectionAlg != 0) {
-        if (!OSSL_CMP_validate_msg(ctx, msg)) {
-            /* validation failed */
-             CMPerr(CMP_F_OSSL_CMP_MSG_CHECK_RECEIVED,
-                    CMP_R_ERROR_VALIDATING_PROTECTION);
-             return -1;
-         }
-    } else {
+    if (!OSSL_CMP_validate_msg(ctx, msg)) {
+        /* validation failed */
+        CMPerr(CMP_F_OSSL_CMP_MSG_CHECK_RECEIVED,
+                CMP_R_ERROR_VALIDATING_PROTECTION);
         /* detect explicitly permitted exceptions */
         if (allow_unprotected == NULL ||
-            !(*allow_unprotected)(ctx, callback_arg, msg)) {
-            CMPerr(CMP_F_OSSL_CMP_MSG_CHECK_RECEIVED,
-                   CMP_R_MISSING_PROTECTION);
+                !(*allow_unprotected)(ctx, callback_arg, msg)) {
+            CMPerr(CMP_F_OSSL_CMP_MSG_CHECK_RECEIVED, CMP_R_MISSING_PROTECTION);
             return -1;
+        } else {
+            OSSL_CMP_warn(ctx, "received PKIMessage has no valid protection");
         }
-        OSSL_CMP_warn(ctx, "received message is not protected");
     }
 
     /* check CMP version number in header */

--- a/doc/man1/cmp.pod
+++ b/doc/man1/cmp.pod
@@ -267,8 +267,9 @@ else C<digitalSignature> must be allowed for signer certificate.
 =item B<-unprotectederrors>
 
 Accept unprotected messages by the server even if they should have been
-protected.  This applies to the following message types received from the
-server:
+protected.  Unprotected means no protection indicated in the PKIMessage header,
+or protection which was not successfully validated.  This option applies to the
+following message types received from the server:
 
 =over 4
 

--- a/doc/man3/OSSL_CMP_CTX_create.pod
+++ b/doc/man3/OSSL_CMP_CTX_create.pod
@@ -300,9 +300,10 @@ RFC 4210.
         Else, 'digitalSignature' must be allowed by CMP signer certificates.
 
     OSSL_CMP_CTX_OPT_UNPROTECTED_ERRORS
-        Accept unprotected error responses: regular error messages as well as
-        certificate responses (IP/CP/KUP) and revocation responses (RP)
-        with rejection.
+        Accept unprotected error responses which are either explicitly
+        unprotected or where protection verification failed. Applies to regular
+        error messages as well as certificate responses (IP/CP/KUP) and
+        revocation responses (RP) with rejection.
 B<WARNING:> This setting leads to unspecified behavior and it is meant
 exclusively to allow interoperability with server implementations violating
 RFC 4210.


### PR DESCRIPTION
As discussed in #158

If non-verifyable protection is just rejected, then there is no way to see details about errors (protected with MSG_SIG_ALG as per RFC) or IP with rejection (potentially protected with MSG_SIG_ALG) if the client doesn't have a trust anchor yet, which is e.g. the case when it does IR with MSG_MAC_ALG (expecting to get the TA from IP).

The -unprotectederrors parameter is the natural candidate to include that as no protection = not valid protection and it does not increase the attack surface as negative results from transactions using -unprotectederrors may anyway at max used for information for e.g. human users, but not to automatically change state of e.g. any technical device.

As a result of this, information about errors / rejections is also displayed to the user.

- [ x ] documentation is added or updated
- [ o ] tests are added or updated
