### PR TITLE
Replacing HMAC when calculating PBM with EVP_MAC

### DIFF
--- a/crypto/cmp/cmp_lib.c
+++ b/crypto/cmp/cmp_lib.c
@@ -581,7 +581,6 @@ ASN1_BIT_STRING *CMP_calc_protection(const OSSL_CMP_MSG *msg,
 
     int l;
     size_t prot_part_der_len;
-    unsigned int mac_len;
     unsigned char *prot_part_der = NULL;
     size_t sig_len;
     unsigned char *protection = NULL;
@@ -619,9 +618,8 @@ ASN1_BIT_STRING *CMP_calc_protection(const OSSL_CMP_MSG *msg,
 
             if (!(OSSL_CRMF_pbm_new(pbm, prot_part_der, prot_part_der_len,
                                     secret->data, secret->length,
-                                    &protection, &mac_len)))
+                                    &protection, &sig_len)))
                 goto err;
-            sig_len = mac_len;
         } else {
             CMPerr(CMP_F_CMP_CALC_PROTECTION, CMP_R_WRONG_ALGORITHM_OID);
             goto err;

--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -114,7 +114,7 @@ OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(size_t slen, int owfnid,
  * |sec| key to use
  * |seclen| length of the key
  * |mac| pointer to the computed mac, will be set on success
- * |maclen| will set variable to the length of the mac on success
+ * |maclen| if not NULL, will set variable to the length of the mac on success
  * returns 1 on success, 0 on error
  */
 int OSSL_CRMF_pbm_new(const OSSL_CRMF_PBMPARAMETER *pbmp,

--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -13,7 +13,7 @@
 
 
 #include <openssl/rand.h>
-#include <openssl/hmac.h>
+#include <openssl/evp.h>
 
 #include "crmf_int.h"
 
@@ -114,13 +114,13 @@ OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(size_t slen, int owfnid,
  * |sec| key to use
  * |seclen| length of the key
  * |mac| pointer to the computed mac, will be set on success
- * |maclen| if not NULL, will set variable to the length of the mac on success
+ * |maclen| will set variable to the length of the mac on success
  * returns 1 on success, 0 on error
  */
 int OSSL_CRMF_pbm_new(const OSSL_CRMF_PBMPARAMETER *pbmp,
                       const unsigned char *msg, size_t msglen,
                       const unsigned char *sec, size_t seclen,
-                      unsigned char **mac, unsigned int *maclen)
+                      unsigned char **mac, size_t *maclen)
 {
     int mac_nid, hmac_md_nid = NID_undef;
     const EVP_MD *m = NULL;
@@ -130,6 +130,7 @@ int OSSL_CRMF_pbm_new(const OSSL_CRMF_PBMPARAMETER *pbmp,
     int64_t iterations;
     unsigned char *mac_res = 0;
     int ok = 0;
+    EVP_MAC_CTX *mctx = NULL;
 
     if (mac == NULL || pbmp == NULL || pbmp->mac == NULL
         || pbmp->mac->algorithm == NULL || msg == NULL || sec == NULL) {
@@ -196,12 +197,21 @@ int OSSL_CRMF_pbm_new(const OSSL_CRMF_PBMPARAMETER *pbmp,
         CRMFerr(CRMF_F_OSSL_CRMF_PBM_NEW, CRMF_R_UNSUPPORTED_ALGORITHM);
         goto err;
     }
-    if (HMAC(m, basekey, bklen, msg, msglen, mac_res, maclen) != NULL)
-        ok = 1;
+
+    if ((mctx = EVP_MAC_CTX_new(EVP_get_macbyname("HMAC"))) == NULL
+        || EVP_MAC_ctrl(mctx, EVP_MAC_CTRL_SET_MD, m) <= 0
+        || EVP_MAC_ctrl(mctx, EVP_MAC_CTRL_SET_KEY, basekey, bklen) <= 0
+        || !EVP_MAC_init(mctx)
+        || !EVP_MAC_update(mctx, msg, msglen)
+        || !EVP_MAC_final(mctx, mac_res, maclen))
+        goto err;
+
+    ok = 1;
 
  err:
     /* cleanup */
     OPENSSL_cleanse(basekey, bklen);
+    EVP_MAC_CTX_free(mctx);
     EVP_MD_CTX_free(ctx);
 
     if (ok == 1) {

--- a/doc/man3/OSSL_CRMF_pbmp_new.pod
+++ b/doc/man3/OSSL_CRMF_pbmp_new.pod
@@ -13,7 +13,7 @@ OSSL_CRMF_pbmp_new
   int OSSL_CRMF_pbm_new(const OSSL_CRMF_PBMPARAMETER *pbmp,
                         const unsigned char *msg, size_t msglen,
                         const unsigned char *sec, size_t seclen,
-                        unsigned char **mac, unsigned int *maclen);
+                        unsigned char **mac, size_t *maclen);
 
   OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(size_t saltlen, int owfnid,
                                              int itercnt, int macnid);
@@ -55,7 +55,7 @@ structure, or NULL on error.
  unsigned char *msg = "Hello";
  unsigned char *sec = "SeCrEt";
  unsigned char *mac = NULL;
- unsigned int maclen;
+ size_t maclen;
 
  if ((pbm = OSSL_CRMF_pbmp_new(16, NID_sha256, 500, NID_hmac_sha1) == NULL))
      goto err;

--- a/include/openssl/crmf.h
+++ b/include/openssl/crmf.h
@@ -70,7 +70,7 @@ OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(size_t slen, int owfnid,
 int OSSL_CRMF_pbm_new(const OSSL_CRMF_PBMPARAMETER *pbmp,
                       const unsigned char *msg, size_t msglen,
                       const unsigned char *sec, size_t seclen,
-                      unsigned char **mac, unsigned int *maclen);
+                      unsigned char **mac, size_t *maclen);
 
 /* crmf_lib.c */
 int OSSL_CRMF_MSG_set1_regCtrl_regToken(OSSL_CRMF_MSG *msg,


### PR DESCRIPTION
as suggested by Matt Caswell

changes in other files due to changing mac_len to size_t

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x ] documentation is added or updated
- [ ] tests are added or updated
