### PR TITLE
Allowing cmp -sans to digest host names starting with a digit

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2178,6 +2178,7 @@ static int set_gennames(char *names, int type,
                        OSSL_CMP_CTX *ctx, const char *desc)
 {
     char *next;
+
     for (; names != NULL; names = next) {
         GENERAL_NAME *n;
         next = next_item(names);
@@ -2187,9 +2188,9 @@ static int set_gennames(char *names, int type,
                       OSSL_CMP_CTX_OPT_SUBJECTALTNAME_CRITICAL, 1);
             continue;
         }
-        if (type != GEN_DNS || isdigit(names[0])) {
-            n = a2i_GENERAL_NAME(NULL, NULL, NULL,
-                                 type != GEN_DNS ? type : GEN_IPADD, names, 0);
+
+        if (type != GEN_DNS) {
+            n = a2i_GENERAL_NAME(NULL, NULL, NULL, type, names, 0);
         } else { /* try IP address first, then domain name */
             (void)ERR_set_mark();
             n = a2i_GENERAL_NAME(NULL, NULL, NULL, GEN_IPADD, names, 0);


### PR DESCRIPTION
See RFC 1123, October 1989

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
