### PR TITLE
Check not only the notAfter field, but also the notBefore field of certs and CRLs.

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1024,11 +1024,15 @@ static int load_certs_also_pkcs12(const char *file, STACK_OF(X509) **certs,
     }
 
     for (i = 0; ret && i < sk_X509_num(*certs); i++) {
+        int cmp;
         cert = sk_X509_value(*certs, i);
-        if (OSSL_CMP_expired(X509_get0_notAfter(cert), vpm)) {
+        cmp = OSSL_CMP_cmp_timeframe(X509_get0_notBefore(cert),
+                                     X509_get0_notAfter (cert), vpm);
+        if (cmp != 0) {
             char *s = X509_NAME_oneline(X509_get_subject_name(cert), NULL, 0);
             BIO_printf(bio_err,
-                     "warning: certificate with subject '%s' has expired\n", s);
+                       "warning: certificate with subject '%s' %s\n", s,
+                       cmp > 0 ? "has expired" : "not yet valid");
             OPENSSL_free(s);
 #if 0
             sk_X509_pop_free(*certs, X509_free);
@@ -2571,22 +2575,26 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx, STACK_OF(X509_CRL) **all_cr
             if (crls == NULL)
                 goto err;
             while ((crl = sk_X509_CRL_shift(crls)) != NULL) {
-                if (!sk_X509_CRL_push(*all_crls, crl)) {
-                    sk_X509_CRL_pop_free(crls, X509_CRL_free);
-                    goto oom;
-                }
-                if (OSSL_CMP_expired(X509_CRL_get0_nextUpdate(crl), vpm)) {
+                int cmp =
+                    OSSL_CMP_cmp_timeframe(X509_CRL_get0_lastUpdate(crl),
+                                           X509_CRL_get0_nextUpdate(crl), vpm);
+                if (cmp != 0) {
           /* well, should ignore expiration of base CRL if delta CRL is valid */
                     char *issuer =
                         X509_NAME_oneline(X509_CRL_get_issuer(crl), NULL, 0);
                     OSSL_CMP_printf(ctx, OSSL_CMP_FL_WARN,
-                                    "CRL from '%s' issued by '%s' has expired",
-                                    opt_crls, issuer);
+                                    "CRL from '%s' issued by '%s' %s",
+                                    opt_crls, issuer,
+                                    cmp > 0 ? "has expired" : "not yet valid");
                     OPENSSL_free(issuer);
 #if 0
                     sk_X509_CRL_pop_free(crls, X509_CRL_free);
                     goto err;
 #endif
+                }
+                if (!sk_X509_CRL_push(*all_crls, crl)) {
+                    sk_X509_CRL_pop_free(crls, X509_CRL_free);
+                    goto oom;
                 }
             }
             sk_X509_CRL_free(crls);

--- a/doc/man3/OSSL_CMP_validate_msg.pod
+++ b/doc/man3/OSSL_CMP_validate_msg.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-OSSL_CMP_expired,
+OSSL_CMP_cmp_timeframe,
 OSSL_CMP_validate_msg,
 OSSL_CMP_validate_cert_path,
 OSSL_CMP_print_cert_verify_cb
@@ -11,7 +11,8 @@ OSSL_CMP_print_cert_verify_cb
 =head1 SYNOPSIS
 
  #include <openssl/cmp.h>
- int OSSL_CMP_expired(const ASN1_TIME *endtime, const X509_VERIFY_PARAM *vpm);
+ int OSSL_CMP_check_time(const ASN1_TIME *start,
+                         const ASN1_TIME *end,  const X509_VERIFY_PARAM *vpm);
  int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg);
  int OSSL_CMP_validate_cert_path(OSSL_CMP_CTX *ctx,
                                  const X509_STORE *trusted_store,
@@ -24,8 +25,9 @@ This is the API for validating the protection of CMP messages,
 which includes validating CMP server certificates and their paths
 while optionally checking the revocation status of the certificates(s).
 
-OSSL_CMP_expired() is a helper function checking if expiration should be checked
-according to the given verification parameters and the given time has passed.
+OSSL_CMP_cmp_timeframe() compares the given time period with the current time.
+If verification parameters are given and X509_V_FLAG_USE_CHECK_TIME is set
+the reference time included there is used instead of the current time.
 
 OSSL_CMP_validate_msg() validates the protection of the given PKIMessage
 using either password-based mac (PBM) or a signature algorithm.
@@ -69,8 +71,9 @@ CMP is defined in RFC 4210 (and CRMF in RFC 4211).
 
 =head1 RETURN VALUES
 
-OSSL_CMP_expired() returns 1 if expiration should be checked
-and the given time has passed, and 0 otherwise.
+OSSL_CMP_cmp_timeframe() returns 0 if X509_V_FLAG_NO_CHECK_TIME is set in the
+given verification parameters or the reference time is within the given bounds,
+1 if it is past the end time, and -1 if it is before the start time.
 
 OSSL_CMP_validate_msg() returns 1 on success, 0 on error or validation failed.
 

--- a/include/openssl/cmp.h
+++ b/include/openssl/cmp.h
@@ -412,7 +412,8 @@ int OSSL_CMP_X509_STORE_add1_certs(X509_STORE *store, STACK_OF(X509) *certs,
 STACK_OF(X509) *OSSL_CMP_X509_STORE_get1_certs(const X509_STORE *store);
 
 /* cmp_vfy.c */
-int OSSL_CMP_expired(const ASN1_TIME *endtime, const X509_VERIFY_PARAM *vpm);
+int OSSL_CMP_cmp_timeframe(const ASN1_TIME *start,
+                           const ASN1_TIME *end,  const X509_VERIFY_PARAM *vpm);
 int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg);
 int OSSL_CMP_validate_cert_path(const OSSL_CMP_CTX *ctx,
                                 const X509_STORE *trusted_store,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4860,7 +4860,7 @@ OSSL_CMP_sk_X509_add1_cert              4805	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_sk_X509_add1_certs             4806	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_X509_STORE_add1_certs          4807	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_X509_STORE_get1_certs          4808	3_0_0	EXIST::FUNCTION:CMP
-OSSL_CMP_expired                        4809	3_0_0	EXIST::FUNCTION:CMP
+OSSL_CMP_cmp_timeframe                  4809	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_validate_msg                   4810	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_validate_cert_path             4811	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_print_cert_verify_cb           4812	3_0_0	EXIST::FUNCTION:CMP


### PR DESCRIPTION
This is the first chunk extracted from #170.
Extends `OSSL_CMP_expired()` to `OSSL_CMP_cmp_timeframe()`, checking not only the `notAfter` field, but also the `notBefore` field of certs and CRLs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
