### PR TITLE
Improve extra certs

### DIFF
--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -353,7 +353,7 @@ STACK_OF(X509) *OSSL_CMP_CTX_extraCertsIn_get1(const OSSL_CMP_CTX *ctx)
 }
 
 /*
- * Copies the given stack of inbound X509 certificates to extraCertsIn of
+ * Copies any given stack of inbound X509 certificates to extraCertsIn of
  * the OSSL_CMP_CTX structure so that they may be retrieved later.
  * returns 1 on success, 0 on error
  */
@@ -363,7 +363,7 @@ int OSSL_CMP_CTX_set1_extraCertsIn(OSSL_CMP_CTX *ctx,
     if (ctx == NULL)
         goto err;
     if (extraCertsIn == NULL)
-        goto err;
+        return 1;
 
     /* if there are already inbound extraCerts on the stack delete them */
     if (ctx->extraCertsIn != NULL) {

--- a/crypto/cmp/cmp_ses.c
+++ b/crypto/cmp/cmp_ses.c
@@ -518,7 +518,6 @@ static int cert_response(OSSL_CMP_CTX *ctx, int rid, OSSL_CMP_MSG **resp,
     const char *txt = NULL;
     OSSL_CMP_CERTREPMESSAGE *crepmsg;
     OSSL_CMP_CERTRESPONSE *crep;
-    STACK_OF(X509) *extracerts;
     int ret = 1;
 
  retry:
@@ -572,16 +571,8 @@ static int cert_response(OSSL_CMP_CTX *ctx, int rid, OSSL_CMP_MSG **resp,
         return 0;
 
     /* copy received extraCerts to ctx->extraCertsIn so they can be retrieved */
-    if ((extracerts = (*resp)->extraCerts) != NULL) {
-        if (!OSSL_CMP_CTX_set1_extraCertsIn(ctx, extracerts) ||
-        /*
-         * merge them also into the untrusted certs, such that the peer does
-         * not need to send them again (in this and any further transaction)
-         */
-            !OSSL_CMP_sk_X509_add1_certs(ctx->untrusted_certs, extracerts,
-                                         0, 1/* no dups */))
-            return 0;
-    }
+    if (!OSSL_CMP_CTX_set1_extraCertsIn(ctx, (*resp)->extraCerts))
+        return 0;
 
     if (!(X509_check_private_key(ctx->newClCert,
                                  ctx->newPkey != NULL ? ctx->newPkey

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -500,7 +500,7 @@ static int find_server_cert(const X509_STORE *ts,
     STACK_OF(X509) *trusted;
 
     if (ts == NULL || msg == NULL || found_certs == NULL)
-        return NULL; /* maybe better flag and handle this as fatal error */
+        return 0; /* maybe better flag and handle this as fatal error */
 
     if (!find_acceptable_certs(untrusted, msg, ts, found_certs))
         return 0;

--- a/doc/man3/OSSL_CMP_CTX_create.pod
+++ b/doc/man3/OSSL_CMP_CTX_create.pod
@@ -353,8 +353,8 @@ of X.509 certificates received in the extraCerts field of last received
 certificate response message IP/CP/KUP which had extraCerts set.
 Returns an empty stack if no extraCerts have been received and NULL on error.
 
-OSSL_CMP_CTX_set1_extraCertsIn() sets the stack of extraCerts that was
-received from remote.
+OSSL_CMP_CTX_set1_extraCertsIn() stores any extraCerts received from remote.
+Nothing happens if the B<extraCertsIn> argument is NULL.
 
 OSSL_CMP_CTX_set0_trustedStore() sets the X509_STORE type certificate store
 containing trusted (root) CA certificates and possibly CRLs and a certificate

--- a/doc/man3/OSSL_CMP_CTX_create.pod
+++ b/doc/man3/OSSL_CMP_CTX_create.pod
@@ -157,7 +157,7 @@ OSSL_CMP_CTX_subjectAltName_push1
  int OSSL_CMP_CTX_reqExtensions_have_SAN(OSSL_CMP_CTX *ctx);
 
  int OSSL_CMP_CTX_set_certConf_cb(OSSL_CMP_CTX *ctx, OSSL_cmp_certConf_cb_t cb);
- int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, const X509 *cert, int fail_info,
+ int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
                           const char **text);
  int OSSL_CMP_CTX_set_certConf_cb_arg(OSSL_CMP_CTX *ctx, void *arg);
  void *OSSL_CMP_CTX_get_certConf_cb_arg(OSSL_CMP_CTX *ctx);
@@ -509,7 +509,7 @@ OSSL_CMP_CTX_set_certConf_cb() sets the callback used for evaluating the newly
 enrolled certificate before the library sends, depending on its result,
 a positive or negative certConf messge to the server. The callback has type
 
- typedef int (*OSSL_cmp_certConf_cb_t) (OSSL_CMP_CTX *ctx, const X509 *cert,
+ typedef int (*OSSL_cmp_certConf_cb_t) (OSSL_CMP_CTX *ctx, X509 *cert,
                                         int fail_info, const char **txt);
 
 and should inspect the certificate it obtains via the B<cert> parameter and may

--- a/doc/man3/OSSL_CMP_MSG_protect.pod
+++ b/doc/man3/OSSL_CMP_MSG_protect.pod
@@ -81,9 +81,10 @@ OSSL_CMP_X509_STORE_get1_certs
   int OSSL_CMP_ASN1_OCTET_STRING_set1_bytes(ASN1_OCTET_STRING **tgt,
                                        const unsigned char *bytes, size_t len);
   int OSSL_CMP_sk_X509_add1_cert(STACK_OF(X509) *sk, X509 *cert,
-                                 int not_duplicate);
-  int OSSL_CMP_sk_X509_add1_certs(STACK_OF(X509) *sk, STACK_OF(X509) *certs,
-                             int no_self_signed, int no_duplicates);
+                                 int not_duplicate, int prepend);
+  int OSSL_CMP_sk_X509_add1_certs(STACK_OF(X509) *sk,
+                                  const STACK_OF(X509) *certs,
+                                  int no_self_signed, int no_duplicates);
   int OSSL_CMP_X509_STORE_add1_certs(X509_STORE *store, STACK_OF(X509) *certs,
                                 int only_self_signed);
   STACK_OF(X509) *OSSL_CMP_X509_STORE_get1_certs(const X509_STORE *store);
@@ -196,11 +197,12 @@ OSSL_CMP_ASN1_OCTET_STRING_set1_bytes() frees any previous value of the variable
 referenced via the first argument and assigns either a copy of the given byte
 string (with the given length) or NULL. It returns 1 on success, 0 on error.
 
-OSSL_CMP_sk_X509_add1_cert() adds a certificate to given stack, optionally only
-if not already contained.
+OSSL_CMP_sk_X509_add1_cert() appends or prepends (depending on the B<prepend>
+argument) a certificate to the given list,
+optionally only if it is not already contained.
 
-OSSL_CMP_sk_X509_add1_certs() adds certificates to given stack, optionally only
-if not self-signed and optionally only if not already contained.
+OSSL_CMP_sk_X509_add1_certs() appenda a list of certificates to the given list,
+optionally only if not self-signed and optionally only if not already contained.
 
 OSSL_CMP_X509_STORE_add1_certs() adds all or only self-signed certificates from
 the given stack to given store.

--- a/doc/man3/OSSL_CMP_validate_msg.pod
+++ b/doc/man3/OSSL_CMP_validate_msg.pod
@@ -14,9 +14,9 @@ OSSL_CMP_print_cert_verify_cb
  int OSSL_CMP_check_time(const ASN1_TIME *start,
                          const ASN1_TIME *end,  const X509_VERIFY_PARAM *vpm);
  int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg);
- int OSSL_CMP_validate_cert_path(OSSL_CMP_CTX *ctx,
-                                 const X509_STORE *trusted_store,
-                                 const X509 *cert, int defer_errors);
+ int OSSL_CMP_validate_cert_path(const OSSL_CMP_CTX *ctx,
+                                 X509_STORE *trusted_store,
+                                 X509 *cert, int defer_errors);
  int OSSL_CMP_print_cert_verify_cb(int ok, X509_STORE_CTX *ctx);
 
 =head1 DESCRIPTION

--- a/include/openssl/cmp.h
+++ b/include/openssl/cmp.h
@@ -275,7 +275,7 @@ void OSSL_CMP_print_errors(OSSL_CMP_CTX *ctx);
 typedef int (*OSSL_cmp_log_cb_t) (const char *component,
                                   const char *file, int lineno,
                                   OSSL_CMP_severity level, const char *msg);
-typedef int (*OSSL_cmp_certConf_cb_t) (OSSL_CMP_CTX *ctx, const X509 *cert,
+typedef int (*OSSL_cmp_certConf_cb_t) (OSSL_CMP_CTX *ctx, X509 *cert,
                                        int fail_info, const char **txt);
 typedef BIO *(*OSSL_cmp_http_cb_t) (OSSL_CMP_CTX *ctx, BIO *hbio,
                                     unsigned long detail);
@@ -418,14 +418,15 @@ int OSSL_CMP_X509_STORE_add1_certs(X509_STORE *store, STACK_OF(X509) *certs,
 STACK_OF(X509) *OSSL_CMP_X509_STORE_get1_certs(const X509_STORE *store);
 
 /* cmp_vfy.c */
+/* TODO better push OSSL_CMP_cmp_timeframe() to crypto/x509/x509_vfy.c */
 int OSSL_CMP_cmp_timeframe(const ASN1_TIME *start,
                            const ASN1_TIME *end,  const X509_VERIFY_PARAM *vpm);
 int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg);
-int OSSL_CMP_validate_cert_path(const OSSL_CMP_CTX *ctx,
-                                const X509_STORE *trusted_store,
-                                const X509 *cert, int defer_errors);
+int OSSL_CMP_validate_cert_path(OSSL_CMP_CTX *ctx,
+                                X509_STORE *trusted_store,
+                                X509 *cert, int defer_errors);
 int OSSL_CMP_print_cert_verify_cb(int ok, X509_STORE_CTX *ctx);
-int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, const X509 *cert, int fail_info,
+int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
                          const char **text);
 
 /*

--- a/include/openssl/cmp.h
+++ b/include/openssl/cmp.h
@@ -410,7 +410,7 @@ int OSSL_CMP_ASN1_OCTET_STRING_set1_bytes(ASN1_OCTET_STRING **tgt,
                                           const unsigned char *bytes,
                                           size_t len);
 int OSSL_CMP_sk_X509_add1_cert (STACK_OF(X509) *sk, X509 *cert,
-                                int not_duplicate);
+                                int not_duplicate, int prepend);
 int OSSL_CMP_sk_X509_add1_certs(STACK_OF(X509) *sk, const STACK_OF(X509) *certs,
                                 int no_self_signed, int no_duplicates);
 int OSSL_CMP_X509_STORE_add1_certs(X509_STORE *store, STACK_OF(X509) *certs,


### PR DESCRIPTION
This  moves the addition of received extraCerts to untrusted certs in the CMP_CTX already before checking msg and prepends them to the untrusted certs. This is  security-neutral, makes the verification more efficient (since the protecting cert is usually in the extraCerts, so they should be tried first) and simplifies the verification code a little. 
Moreover, this PR fixes a couple of wrong `const` function argument modifiers and update the TODOs.

- [x] documentation is added or updated

