### PR TITLE
Revocation api

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -210,7 +210,7 @@ typedef enum OPTION_choice {
     OPT_OUT_TRUSTED, OPT_IMPLICIT_CONFIRM, OPT_DISABLE_CONFIRM,
     OPT_CERTOUT, OPT_CHAINOUT,
 
-    OPT_OLDCERT, OPT_REVREASON,
+    OPT_OLDCERT, OPT_REVREASON, OPT_SERIALNUMBER,
 
 #ifndef OPENSSL_NO_SOCK
     OPT_SERVER, OPT_PROXY, OPT_NO_PROXY,
@@ -296,6 +296,8 @@ const OPTIONS cmp_options[] = {
      "DN of the issuer to place in the requested certificate template"},
     {OPT_MORE_STR, 0, 0,
      "also used as recipient if neither -recipient nor -srvcert are given"},
+    {OPT_MORE_STR, 0, 0,
+     "or to be revoked in rr"},
     {"days", OPT_DAYS, 'N',
      "Requested validity time of the new certificate in number of days"},
     {"reqexts", OPT_REQEXTS, 's',
@@ -343,6 +345,8 @@ const OPTIONS cmp_options[] = {
      "Reason code to include in revocation request (rr); possible values:"},
     {OPT_MORE_STR, 0, 0,
      "0..6, 8..10 (see RFC5280, 5.3.1) or -1. Default -1 = none included"},
+     {"serialnumber", OPT_SERIALNUMBER, 's',
+     "Serial number of certificate to be revoked in revocation request (rr)"},
 
     OPT_SECTION("Message transfer"),
 #ifdef OPENSSL_NO_SOCK

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1522,9 +1522,9 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 }
 
 /*
- * set up IR/CR/KUR/CertConf/RR specific parts of the OSSL_CMP_CTX
- * based on options from config file/CLI.
- * Returns pointer on success, NULL on error
+ * Set up IR/CR/P10CR/KUR/CertConf/RR/GENM specific parts of the OSSL_CMP_CTX
+ * based on options from CLI and/or config file.
+ * Returns 1 on success, 0 on error
  */
 static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 {

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -337,7 +337,7 @@ const OPTIONS cmp_options[] = {
     {OPT_MORE_STR, 0, 0,
      "Issuer is used as recipient unless -recipient, -srvcert, or -issuer given"},
     {"issuer", OPT_ISSUER, 's',
-     "DN of the issuer to place in the requested certificate template or rr "},
+     "DN of the issuer to place in the certificate template of ir/cr/kur/rr;"},
     {OPT_MORE_STR, 0, 0,
      "also used as recipient if neither -recipient nor -srvcert are given"},
     {"serial", OPT_SERIAL, 's',

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -911,7 +911,8 @@ int OSSL_CMP_exec_RR_ses(OSSL_CMP_CTX *ctx)
         return 0;
     }
     ctx->status = OSSL_CMP_PKISTATUS_request;
-    if (ctx->oldCert == NULL && ctx->p10CSR == NULL) {
+    if (ctx->oldCert == NULL && ctx->p10CSR == NULL
+        && (ctx->serialNumber == NULL || ctx->issuer == NULL)) {
         ERR_raise(ERR_LIB_CMP, CMP_R_MISSING_REFERENCE_CERT);
         return 0;
     }

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -232,6 +232,7 @@ void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx)
 
     EVP_PKEY_free(ctx->newPkey);
     X509_NAME_free(ctx->issuer);
+    ASN1_INTEGER_free(ctx->serialNumber);
     X509_NAME_free(ctx->subjectName);
     sk_GENERAL_NAME_pop_free(ctx->subjectAltNames, GENERAL_NAME_free);
     X509_EXTENSIONS_free(ctx->reqExtensions);
@@ -663,6 +664,8 @@ DEFINE_OSSL_CMP_CTX_set1(expected_sender, X509_NAME)
 /* Set the X509 name of the issuer to be placed in the certTemplate */
 DEFINE_OSSL_CMP_CTX_set1(issuer, X509_NAME)
 
+/* Set the ASN1_INTEGER serial to be placed in the certTemplate for rr */
+DEFINE_OSSL_CMP_CTX_set1(serialNumber, ASN1_INTEGER)
 /*
  * Set the subject name that will be placed in the certificate
  * request. This will be the subject name on the received certificate.

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -107,7 +107,8 @@ struct ossl_cmp_ctx_st {
     /* certificate template */
     EVP_PKEY *newPkey; /* explicit new private/public key for cert enrollment */
     int newPkey_priv; /* flag indicating if newPkey contains private key */
-    X509_NAME *issuer; /* issuer name to used in cert template */
+    X509_NAME *issuer; /* issuer name to used in cert template, also in rr */
+    ASN1_INTEGER *serialNumber; /* certificate serial number to use in rr */
     int days; /* Number of days new certificates are asked to be valid for */
     X509_NAME *subjectName; /* subject name to be used in cert template */
     STACK_OF(GENERAL_NAME) *subjectAltNames; /* to add to the cert template */

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -561,16 +561,22 @@ OSSL_CMP_MSG *ossl_cmp_rr_new(OSSL_CMP_CTX *ctx)
         goto err;
 
     /* Fill the template from the contents of the certificate to be revoked */
-    ret = ctx->oldCert != NULL
-    ? OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails,
-                                  NULL /* pubkey would be redundant */,
-                                  NULL /* subject would be redundant */,
-                                  X509_get_issuer_name(ctx->oldCert),
-                                  X509_get0_serialNumber(ctx->oldCert))
-    : OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails,
-                                  X509_REQ_get0_pubkey(ctx->p10CSR),
-                                  X509_REQ_get_subject_name(ctx->p10CSR),
-                                  NULL, NULL);
+    ret = ctx->serialNumber != NULL && ctx->issuer != NULL
+        ? OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails,
+                                      NULL /* pubkey would be redundant */, 0,
+                                      NULL /* subject would be redundant */,
+                                      ctx->issuer,
+                                      ctx->serialNumber)
+        : ctx->oldCert != NULL
+        ? OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails,
+                                      NULL /* pubkey would be redundant */, 0,
+                                      NULL /* subject would be redundant */,
+                                      X509_get_issuer_name(ctx->oldCert),
+                                      X509_get0_serialNumber(ctx->oldCert))
+        : OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails,
+                                      X509_REQ_get0_pubkey(ctx->p10CSR), 0,
+                                      X509_REQ_get_subject_name(ctx->p10CSR),
+                                      NULL, NULL);
     if (!ret)
         goto err;
 

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -20,11 +20,11 @@
 #include <openssl/err.h>
 #include <openssl/x509.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x30000000L   
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 # define OSSL_CMP_PKISI_dup(si) OSSL_CMP_PKISI_dup((OSSL_CMP_PKISI *)(si)) /* hack */
 # define OSSL_CRMF_CERTID_dup(ci) OSSL_CRMF_CERTID_dup((OSSL_CRMF_CERTID *)(ci)) /* hack */
 # define ASN1_item_i2d(val, out, it) ASN1_item_i2d((ASN1_VALUE *)(val), out, it); /* hack */
-#endif   
+#endif
 
 #if OPENSSL_VERSION_NUMBER <= 0x30200000L
 
@@ -66,7 +66,6 @@ int ossl_cmp_msg_set0_libctx(OSSL_CMP_MSG *msg, OSSL_LIB_CTX *libctx,
     }
     return 1;
 }
-
 
 OSSL_CMP_PKIHEADER *OSSL_CMP_MSG_get0_header(const OSSL_CMP_MSG *msg)
 {

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -550,7 +550,9 @@ OSSL_CMP_MSG *ossl_cmp_rr_new(OSSL_CMP_CTX *ctx)
 {
     OSSL_CMP_MSG *msg = NULL;
     const X509_NAME *issuer = NULL;
+    const X509_NAME *subject = NULL;
     const ASN1_INTEGER *serialNumber = NULL;
+    EVP_PKEY *pubkey = NULL;
     OSSL_CMP_REVDETAILS *rd;
     int ret;
 
@@ -568,19 +570,17 @@ OSSL_CMP_MSG *ossl_cmp_rr_new(OSSL_CMP_CTX *ctx)
     } else if (ctx->oldCert != NULL) {
         issuer = X509_get_issuer_name(ctx->oldCert);
         serialNumber = X509_get0_serialNumber(ctx->oldCert);
+    } else if (ctx->p10CSR != NULL) {
+        pubkey = X509_REQ_get0_pubkey(ctx->p10CSR);
+        subject = X509_REQ_get_subject_name(ctx->p10CSR);
+    }
+    else {
+        goto err;
     }
 
     /* Fill the template from the contents of the certificate to be revoked */
-    ret = serialNumber != NULL && issuer != NULL
-        ? OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails,
-                                      NULL /* pubkey would be redundant */,
-                                      NULL /* subject would be redundant */,
-                                      issuer,
-                                      serialNumber)
-        : OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails,
-                                      X509_REQ_get0_pubkey(ctx->p10CSR),
-                                      X509_REQ_get_subject_name(ctx->p10CSR),
-                                      NULL, NULL);
+    ret = OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails, pubkey, subject,
+                                      issuer, serialNumber);
     if (!ret)
         goto err;
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -562,8 +562,9 @@ private component then NULL is returned.
 OSSL_CMP_CTX_set1_issuer() sets the name of the intended issuer that
 will be set in the CertTemplate, i.e., the X509 name of the CA server.
 
-OSSL_CMP_CTX_set1_serialNumber() sets the serial number of the certificate
-to be revoked in Revocation Requests (RR).
+OSSL_CMP_CTX_set1_serialNumber() sets the serial number optionally used to
+select the certificate to be revoked in Revocation Requests (RR).
+
 
 OSSL_CMP_CTX_set1_subjectName() sets the subject DN that will be used in
 the CertTemplate structure when requesting a new cert. For Key Update Requests
@@ -597,17 +598,19 @@ to the X509_EXTENSIONS of the requested certificate template.
 
 OSSL_CMP_CTX_set1_oldCert() sets the old certificate to be updated in
 Key Update Requests (KUR) or to be revoked in Revocation Requests (RR).
-It must be given for RR, else it defaults to the CMP signer certificate.
+For KUR the certificate defaults to the CMP signer certificate.
 The I<reference certificate> determined in this way, if any, is also used for
 deriving default subject DN, public key, Subject Alternative Names, and the
 default issuer entry in the requested certificate template of IR/CR/KUR.
 The subject of the reference certificate is used as the sender field value
 in CMP message headers.
 Its issuer is used as default recipient in CMP message headers.
+For RR, this is ignored when issuer and serial is provided using OSSL_CMP_CTX_set1_issuer()
+and OSSL_CMP_CTX_set1_serialNumber() respectivey.
 
 OSSL_CMP_CTX_set1_p10CSR() sets the PKCS#10 CSR to use in P10CR messages.
 If such a CSR is provided, its subject, public key, and extension fields are
-also used as fallback values for the certificate template of IR/CR/KUR messages.
+also used as fallback values for the certificate template of IR/CR/KUR/RR messages.
 
 OSSL_CMP_CTX_push0_genm_ITAV() adds I<itav> to the stack in the I<ctx> which
 will be the body of a General Message sent with this context.
@@ -824,6 +827,8 @@ in OpenSSL 3.1.
 OSSL_CMP_CTX_get0_libctx(), OSSL_CMP_CTX_get0_propq(),
 OSSL_CMP_CTX_get0_validatedSrvCert() and OSSL_CMP_CTX_reset_geninfo_ITAVs()
 were added in OpenSSL 3.1.
+
+OSSL_CMP_CTX_set1_serialNumber() was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -473,7 +473,7 @@ in received CMP messages unless B<OSSL_CMP_OPT_NO_CACHE_EXTRACERTS> is set.
 OSSL_CMP_CTX_get0_untrusted() returns a pointer to the list of untrusted certs
 in I<ctx>, which may be empty if unset.
 
-OSSL_CMP_CTX_set1_cert() sets the CMP signer certificate
+OSSL_CMP_CTX_set1_cert() sets the CMP I<signer certificate>
 related to the private key used for CMP message protection.
 Therefore the public key of this I<cert> must correspond to
 the private key set before or thereafter via OSSL_CMP_CTX_set1_pkey().
@@ -565,7 +565,6 @@ will be set in the CertTemplate, i.e., the X509 name of the CA server.
 OSSL_CMP_CTX_set1_serialNumber() sets the serial number optionally used to
 select the certificate to be revoked in Revocation Requests (RR).
 
-
 OSSL_CMP_CTX_set1_subjectName() sets the subject DN that will be used in
 the CertTemplate structure when requesting a new cert. For Key Update Requests
 (KUR), it defaults to the subject DN of the reference certificate,
@@ -598,19 +597,22 @@ to the X509_EXTENSIONS of the requested certificate template.
 
 OSSL_CMP_CTX_set1_oldCert() sets the old certificate to be updated in
 Key Update Requests (KUR) or to be revoked in Revocation Requests (RR).
-For KUR the certificate defaults to the CMP signer certificate.
-The I<reference certificate> determined in this way, if any, is also used for
-deriving default subject DN, public key, Subject Alternative Names, and the
-default issuer entry in the requested certificate template of IR/CR/KUR.
+For RR, this is ignored if an issuer name and a serial number are provided using
+OSSL_CMP_CTX_set1_issuer() and OSSL_CMP_CTX_set1_serialNumber(), respectively.
+For IR/CR/KUR this sets the I<reference certificate>,
+which otherwise defaults to the CMP signer certificate.
+The I<reference certificate> determined this way, if any, is used for providing
+default public key, subject DN, Subject Alternative Names, and issuer DN entries
+in the requested certificate template of IR/CR/KUR messages.
+
 The subject of the reference certificate is used as the sender field value
 in CMP message headers.
 Its issuer is used as default recipient in CMP message headers.
-For RR, this is ignored when issuer and serial is provided using OSSL_CMP_CTX_set1_issuer()
-and OSSL_CMP_CTX_set1_serialNumber() respectivey.
 
 OSSL_CMP_CTX_set1_p10CSR() sets the PKCS#10 CSR to use in P10CR messages.
-If such a CSR is provided, its subject, public key, and extension fields are
-also used as fallback values for the certificate template of IR/CR/KUR/RR messages.
+If such a CSR is provided, its subject and public key fields are also
+used as fallback values for the certificate template of IR/CR/KUR/RR messages,
+and any extensions included are added to the template of IR/CR/KUR messages.
 
 OSSL_CMP_CTX_push0_genm_ITAV() adds I<itav> to the stack in the I<ctx> which
 will be the body of a General Message sent with this context.

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -43,6 +43,7 @@ OSSL_CMP_CTX_set1_extraCertsOut,
 OSSL_CMP_CTX_set0_newPkey,
 OSSL_CMP_CTX_get0_newPkey,
 OSSL_CMP_CTX_set1_issuer,
+OSSL_CMP_CTX_set1_serialNumber,
 OSSL_CMP_CTX_set1_subjectName,
 OSSL_CMP_CTX_push1_subjectAltName,
 OSSL_CMP_CTX_set0_reqExtensions,
@@ -133,6 +134,7 @@ OSSL_CMP_CTX_set1_senderNonce
  int OSSL_CMP_CTX_set0_newPkey(OSSL_CMP_CTX *ctx, int priv, EVP_PKEY *pkey);
  EVP_PKEY *OSSL_CMP_CTX_get0_newPkey(const OSSL_CMP_CTX *ctx, int priv);
  int OSSL_CMP_CTX_set1_issuer(OSSL_CMP_CTX *ctx, const X509_NAME *name);
+ int OSSL_CMP_CTX_set1_serialNumber(OSSL_CMP_CTX *ctx, const ASN1_INTEGER *sn);
  int OSSL_CMP_CTX_set1_subjectName(OSSL_CMP_CTX *ctx, const X509_NAME *name);
  int OSSL_CMP_CTX_push1_subjectAltName(OSSL_CMP_CTX *ctx,
                                        const GENERAL_NAME *name);
@@ -559,6 +561,9 @@ private component then NULL is returned.
 
 OSSL_CMP_CTX_set1_issuer() sets the name of the intended issuer that
 will be set in the CertTemplate, i.e., the X509 name of the CA server.
+
+OSSL_CMP_CTX_set1_serialNumber() sets the serial number of the certificate
+to be revoked in Revocation Requests (RR).
 
 OSSL_CMP_CTX_set1_subjectName() sets the subject DN that will be used in
 the CertTemplate structure when requesting a new cert. For Key Update Requests

--- a/doc/man3/OSSL_CMP_exec_certreq.pod
+++ b/doc/man3/OSSL_CMP_exec_certreq.pod
@@ -99,7 +99,12 @@ a negative value as the I<req_type> argument then OSSL_CMP_try_certreq()
 aborts the CMP transaction by sending an error message to the server.
 
 OSSL_CMP_exec_RR_ses() requests the revocation of the certificate
-specified in the I<ctx> using L<OSSL_CMP_CTX_set1_oldCert(3)>.
+specified in the I<ctx> using the issuer DN and serial number set by
+OSSL_CMP_CTX_set1_issuer(3) and OSSL_CMP_CTX_set1_serialNumber(3), respectively,
+otherwise the issuer DN and serial number
+of the certificate set by L<OSSL_CMP_CTX_set1_oldCert(3)>,
+otherwise the subject DN and public key
+of the certificate signing request set by L<OSSL_CMP_CTX_set1_p10CSR(3)>.
 RFC 4210 is vague in which PKIStatus should be returned by the server.
 We take "accepted" and "grantedWithMods" as clear success and handle
 "revocationWarning" and "revocationNotification" just as warnings because CAs

--- a/include/cmp/openssl/cmp.h
+++ b/include/cmp/openssl/cmp.h
@@ -559,6 +559,7 @@ int OSSL_CMP_CTX_set1_extraCertsOut(OSSL_CMP_CTX *ctx,
 int OSSL_CMP_CTX_set0_newPkey(OSSL_CMP_CTX *ctx, int priv, EVP_PKEY *pkey);
 EVP_PKEY *OSSL_CMP_CTX_get0_newPkey(const OSSL_CMP_CTX *ctx, int priv);
 int OSSL_CMP_CTX_set1_issuer(OSSL_CMP_CTX *ctx, const X509_NAME *name);
+int OSSL_CMP_CTX_set1_serialNumber(OSSL_CMP_CTX *ctx, const ASN1_INTEGER *sn);
 int OSSL_CMP_CTX_set1_subjectName(OSSL_CMP_CTX *ctx, const X509_NAME *name);
 int OSSL_CMP_CTX_push1_subjectAltName(OSSL_CMP_CTX *ctx,
                                       const GENERAL_NAME *name);

--- a/include/cmp/openssl/cmp.h.in
+++ b/include/cmp/openssl/cmp.h.in
@@ -341,6 +341,7 @@ int OSSL_CMP_CTX_set1_extraCertsOut(OSSL_CMP_CTX *ctx,
 int OSSL_CMP_CTX_set0_newPkey(OSSL_CMP_CTX *ctx, int priv, EVP_PKEY *pkey);
 EVP_PKEY *OSSL_CMP_CTX_get0_newPkey(const OSSL_CMP_CTX *ctx, int priv);
 int OSSL_CMP_CTX_set1_issuer(OSSL_CMP_CTX *ctx, const X509_NAME *name);
+int OSSL_CMP_CTX_set1_serialNumber(OSSL_CMP_CTX *ctx, const ASN1_INTEGER *sn);
 int OSSL_CMP_CTX_set1_subjectName(OSSL_CMP_CTX *ctx, const X509_NAME *name);
 int OSSL_CMP_CTX_push1_subjectAltName(OSSL_CMP_CTX *ctx,
                                       const GENERAL_NAME *name);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5458,6 +5458,7 @@ OSSL_CMP_CTX_reset_geninfo_ITAVs        ?	3_0_8   EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_libctx,               ?	3_2_0   EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_propq,                ?	3_2_0   EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_validatedSrvCert      ?	3_2_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_set1_serialNumber          ?	3_2_0	EXIST::FUNCTION:CMP
 OSSL_CMP_MSG_update_recipNonce          ?	3_0_9	EXIST::FUNCTION:CMP
 OSSL_CMP_SRV_CTX_setup_polling          ?	3_2_0	EXIST::FUNCTION:CMP
 OSSL_CRMF_CERTTEMPLATE_get0_publicKey   ?	3_2_0	EXIST::FUNCTION:CRMF


### PR DESCRIPTION
## Motivation

Be able to issue revocation request using issuer and serial number of certificate to be revoked. 

## Proposed Changes

add -serialnumber and -issuer option for revocation request.

## Test Plan

Added test in gencmpclient using Mock server.