### PR TITLE
Improve HTTP client trace facility

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -756,8 +756,7 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
 
         /* dump all response header lines */
         if (OSSL_TRACE_ENABLED(HTTP)) {
-            if ((rctx->state == OHS_FIRSTLINE && strstr(buf, " 200") == NULL)
-                    || rctx->state == OHS_ERROR)
+            if (rctx->state == OHS_FIRSTLINE || rctx->state == OHS_ERROR)
                 OSSL_TRACE(HTTP, "Received response header:\n");
             OSSL_TRACE1(HTTP, "%s", buf);
         }

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -22,6 +22,17 @@
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/trace.h>
 #endif
+#if OPENSSL_VERSION_NUMBER < 0x30000000L || 1 /* no more use trace API here as it is very hard to enable */
+# define OSSL_TRACE_PREFIX(category) "cmpClient " #category ": "
+# undef OSSL_TRACE_ENABLED
+# define OSSL_TRACE_ENABLED(category) (strstr(getenv("OPENSSL_TRACE"), #category) != NULL)
+# undef OSSL_TRACE
+# define OSSL_TRACE(category, msg) fprintf(stderr, OSSL_TRACE_PREFIX(category) "%s", msg)
+# undef OSSL_TRACE1
+# define OSSL_TRACE1(category, msg, arg1) fprintf(stderr, OSSL_TRACE_PREFIX(category) msg, arg1)
+# undef OSSL_TRACE2
+# define OSSL_TRACE2(category, msg, arg1, arg2) fprintf(stderr, OSSL_TRACE_PREFIX(category) msg, arg1, arg2)
+#endif
 #include "internal/sockets.h"
 #include "internal/common.h" /* for ossl_assert() */
 

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -22,7 +22,8 @@
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/trace.h>
 #endif
-#if OPENSSL_VERSION_NUMBER < 0x30000000L || 1 /* no more use trace API here as it is very hard to enable */
+#if OPENSSL_VERSION_NUMBER < 0x30000000L /* for OpenSSL < 3.0 the follwoing defines are needed */ \
+    || 1 /* yet do not use the trace API also for OpenSSL >= 3.0 as it is hard to enable there */
 # define OSSL_TRACE_PREFIX(category) "cmpClient " #category ": "
 # undef OSSL_TRACE_ENABLED
 # define OSSL_TRACE_ENABLED(category) (strstr(getenv("OPENSSL_TRACE"), #category) != NULL)


### PR DESCRIPTION
* for convenient use with genCMPClient, turn on support for HTTP client tracing ,
  so no special OpenSSL build configured with `enable-trace` is needed, 
  but just `USE_LIBCMP=1` when building the genCMPClient.
* fix missing trace of response header
* distinguish between request/response header and body