### PR TITLE
Add minor CMP client fixes and extensions

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -86,6 +86,8 @@ static char *opt_srvcert = NULL;
 static char *opt_expect_sender = NULL;
 static int opt_ignore_keyusage = 0;
 static int opt_unprotected_errors = 0;
+static int opt_nonmatched_error_nonces = 0;
+
 static int opt_no_cache_extracerts = 0;
 static char *opt_srvcertout = NULL;
 static char *opt_extracertsout = NULL;
@@ -222,8 +224,8 @@ typedef enum OPTION_choice {
 
     OPT_TRUSTED, OPT_UNTRUSTED, OPT_SRVCERT,
     OPT_EXPECT_SENDER,
-    OPT_IGNORE_KEYUSAGE, OPT_UNPROTECTED_ERRORS, OPT_NO_CACHE_EXTRACERTS,
-    OPT_SRVCERTOUT, OPT_EXTRACERTSOUT, OPT_CACERTSOUT,
+    OPT_IGNORE_KEYUSAGE, OPT_UNPROTECTED_ERRORS, OPT_NONMATCHED_ERROR_NONCES,
+    OPT_NO_CACHE_EXTRACERTS, OPT_SRVCERTOUT, OPT_EXTRACERTSOUT, OPT_CACERTSOUT,
 
     OPT_REF, OPT_SECRET, OPT_CERT, OPT_OWN_TRUSTED, OPT_KEY, OPT_KEYPASS,
     OPT_DIGEST, OPT_MAC, OPT_EXTRACERTS,
@@ -389,6 +391,8 @@ const OPTIONS cmp_options[] = {
      "Ignore CMP signer cert key usage, else 'digitalSignature' must be allowed"},
     {"unprotected_errors", OPT_UNPROTECTED_ERRORS, '-',
      "Accept missing or invalid protection of regular error messages and negative"},
+    {"nonmatched_error_nonces", OPT_NONMATCHED_ERROR_NONCES, '-',
+     "Accept missing or non-matching transactionID or recipNonce in error messages"},
     {OPT_MORE_STR, 0, 0,
      "certificate responses (ip/cp/kup), revocation responses (rp), and PKIConf"},
     {OPT_MORE_STR, 0, 0,
@@ -585,6 +589,7 @@ static varref cmp_vars[] = { /* must be in same order as enumerated above! */
     {&opt_trusted}, {&opt_untrusted}, {&opt_srvcert},
     {&opt_expect_sender},
     {(char **)&opt_ignore_keyusage}, {(char **)&opt_unprotected_errors},
+    {(char **)&opt_nonmatched_error_nonces},
     {(char **)&opt_no_cache_extracerts},
     {&opt_srvcertout}, {&opt_extracertsout}, {&opt_cacertsout},
 
@@ -1223,6 +1228,8 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
 
     if (opt_unprotected_errors)
         (void)OSSL_CMP_CTX_set_option(ctx, OSSL_CMP_OPT_UNPROTECTED_ERRORS, 1);
+    if (opt_nonmatched_error_nonces)
+        (void)OSSL_CMP_CTX_set_option(ctx, OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES, 1);
 
     if (opt_out_trusted != NULL) { /* for use in OSSL_CMP_certConf_cb() */
         X509_VERIFY_PARAM *out_vpm = NULL;
@@ -2506,6 +2513,9 @@ static int get_opts(int argc, char **argv)
             break;
         case OPT_UNPROTECTED_ERRORS:
             opt_unprotected_errors = 1;
+            break;
+        case OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES:
+            opt_nonmatched_error_nonces = 1;
             break;
         case OPT_NO_CACHE_EXTRACERTS:
             opt_no_cache_extracerts = 1;

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -792,7 +792,7 @@ static int cert_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
         ERR_raise_data(ERR_LIB_CMP, CMP_R_CERTIFICATE_NOT_ACCEPTED,
                        "rejecting newly enrolled cert with subject: %s; %s",
                        subj, txt);
-        ctx->status = OSSL_CMP_PKISTATUS_rejection;
+        ctx->status = OSSL_CMP_PKISTATUS_rejection_by_client;
         ret = 0;
     }
     OPENSSL_free(subj);

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -129,11 +129,21 @@ OSSL_CMP_CTX *OSSL_CMP_CTX_new(OSSL_LIB_CTX *libctx, const char *propq)
     if ((ctx->untrusted = sk_X509_new_null()) == NULL)
         goto oom;
 
-    ctx->pbm_slen = 16;
+    /* https://www.rfc-editor.org/rfc/rfc9045.html#name-password-based-message-auth */
+    ctx->pbm_slen = 16; /* The salt SHOULD be at least 8 octets (64 bits) long. */
     if (!cmp_ctx_set_md(ctx, &ctx->pbm_owf, NID_sha256))
         goto err;
-    ctx->pbm_itercnt = 500;
+    ctx->pbm_itercnt = 1024; /* 10000 would be recommended; Insta Demo CA always uses 1024 */
+    /*
+     * On count > 2047, Insta Demo CA reports error with PKIFailureInfo: badMessageCheck;
+     * StatusString: "CMP header protection check failed. (...): password based MAC does not match"
+     */
     ctx->pbm_mac = NID_hmac_sha1;
+    /*
+     * By default using HMAC-SHA1 as per https://www.rfc-editor.org/rfc/rfc4211.html#section-4.4
+     * on other values like NID_hmacWithSHA256, Insta Demo CA reports error with badDataFormat;
+     * StatusString: "ASN.1 decoding error"
+     */
 
     if (!cmp_ctx_set_md(ctx, &ctx->digest, NID_sha256))
         goto err;

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -942,6 +942,9 @@ int OSSL_CMP_CTX_set_option(OSSL_CMP_CTX *ctx, int opt, int val)
     case OSSL_CMP_OPT_UNPROTECTED_ERRORS:
         ctx->unprotectedErrors = val;
         break;
+    case OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES:
+        ctx->nonmatchedErrorNonces = val;
+        break;
     case OSSL_CMP_OPT_NO_CACHE_EXTRACERTS:
         ctx->noCacheExtraCerts = val;
         break;
@@ -1027,6 +1030,8 @@ int OSSL_CMP_CTX_get_option(const OSSL_CMP_CTX *ctx, int opt)
         return ctx->unprotectedSend;
     case OSSL_CMP_OPT_UNPROTECTED_ERRORS:
         return ctx->unprotectedErrors;
+    case OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES:
+        return ctx->nonmatchedErrorNonces;
     case OSSL_CMP_OPT_NO_CACHE_EXTRACERTS:
         return ctx->noCacheExtraCerts;
     case OSSL_CMP_OPT_VALIDITY_DAYS:

--- a/crypto/cmp/cmp_hdr.c
+++ b/crypto/cmp/cmp_hdr.c
@@ -291,6 +291,8 @@ int ossl_cmp_hdr_set_transactionID(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr)
 /* fill in all fields of the hdr according to the info given in ctx */
 int ossl_cmp_hdr_init(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr)
 {
+    const ASN1_OCTET_STRING *ref = ctx->referenceValue;
+    X509_NAME *ref_name = NULL;
     const X509_NAME *sender;
     const X509_NAME *rcp = NULL;
 
@@ -301,16 +303,30 @@ int ossl_cmp_hdr_init(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr)
     if (!ossl_cmp_hdr_set_pvno(hdr, OSSL_CMP_PVNO))
         return 0;
 
-    /*
-     * If no protection cert nor oldCert nor CSR nor subject is given,
-     * sender name is not known to the client and thus set to NULL-DN
-     */
-    sender = ctx->cert != NULL ? X509_get_subject_name(ctx->cert) :
-        ctx->oldCert != NULL ? X509_get_subject_name(ctx->oldCert) :
-        ctx->p10CSR != NULL ? X509_REQ_get_subject_name(ctx->p10CSR) :
-        ctx->subjectName;
-    if (!ossl_cmp_hdr_set1_sender(hdr, sender))
-        return 0;
+    if (ctx->secretValue != NULL) {
+        ref_name = X509_NAME_new();
+        if (ref_name == NULL
+            || X509_NAME_add_entry_by_NID(ref_name, NID_commonName, MBSTRING_UTF8,
+                                          ASN1_STRING_get0_data(ref),
+                                          ASN1_STRING_length(ref), -1, 0) != 1)
+            goto err;
+    }
+    if (ctx->secretValue != NULL && ref_name != NULL) {
+        if (!ossl_cmp_hdr_set1_sender(hdr, ref_name))
+            goto err;
+    } else {
+        /*
+         * If no protection cert nor oldCert nor CSR nor subject nor ref is given,
+         * sender name is not known to the client and thus set to NULL-DN
+         */
+        sender = ctx->cert != NULL ? X509_get_subject_name(ctx->cert) :
+            ctx->oldCert != NULL ? X509_get_subject_name(ctx->oldCert) :
+            ctx->p10CSR != NULL ? X509_REQ_get_subject_name(ctx->p10CSR) :
+            ctx->subjectName != NULL ? ctx->subjectName : ref_name;
+        if (!ossl_cmp_hdr_set1_sender(hdr, sender))
+            goto err;
+    }
+    X509_NAME_free(ref_name);
 
     /* determine recipient entry in PKIHeader */
     if (ctx->recipient != NULL)
@@ -367,4 +383,8 @@ int ossl_cmp_hdr_init(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr)
         return 0;
 
     return 1;
+
+ err:
+    X509_NAME_free(ref_name);
+    return 0;
 }

--- a/crypto/cmp/cmp_hdr.c
+++ b/crypto/cmp/cmp_hdr.c
@@ -303,7 +303,7 @@ int ossl_cmp_hdr_init(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr)
     if (!ossl_cmp_hdr_set_pvno(hdr, OSSL_CMP_PVNO))
         return 0;
 
-    if (ctx->secretValue != NULL) {
+    if (ref != NULL) {
         ref_name = X509_NAME_new();
         if (ref_name == NULL
             || X509_NAME_add_entry_by_NID(ref_name, NID_commonName, MBSTRING_UTF8,
@@ -311,7 +311,7 @@ int ossl_cmp_hdr_init(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr)
                                           ASN1_STRING_length(ref), -1, 0) != 1)
             goto err;
     }
-    if (ctx->secretValue != NULL && ref_name != NULL) {
+    if (ctx->secretValue != NULL && ref != NULL) {
         if (!ossl_cmp_hdr_set1_sender(hdr, ref_name))
             goto err;
     } else {

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -65,6 +65,7 @@ struct ossl_cmp_ctx_st {
      * certificate responses (ip/cp/kup), revocation responses (rp), and PKIConf
      */
     int unprotectedErrors;
+    int nonmatchedErrorNonces; /* accept missing/wrong transactionID or recipNonce values in error */
     int noCacheExtraCerts;
     X509 *srvCert; /* certificate used to identify the server */
     X509 *validatedSrvCert; /* caches any already validated server cert */

--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -231,8 +231,25 @@ static X509_ALGOR *sig_algor(const OSSL_CMP_CTX *ctx)
 static int set_senderKID(const OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg,
                          const ASN1_OCTET_STRING *id)
 {
-    if (id == NULL)
-        id = ctx->referenceValue; /* standard for PBM, fallback for sig-based */
+    if (id == NULL && ctx->secretValue != NULL) {
+        /* take fallback senderKID from the commonName in the sender field if available */
+        const GENERAL_NAME *gn = msg->header->sender;
+        const X509_NAME *sender;
+        int res;
+
+        if (gn->type == GEN_DIRNAME && (sender = gn->d.directoryName) != NULL
+            && (res = X509_NAME_get_index_by_NID(sender, NID_commonName, -1)) >= 0) {
+            ASN1_STRING *astr = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(sender, res));
+            ASN1_OCTET_STRING *ostr = NULL;
+
+            if (!ossl_cmp_asn1_octet_string_set1_bytes(&ostr, ASN1_STRING_get0_data(astr),
+                                                       ASN1_STRING_length(astr)))
+                return 0;
+            res = ossl_cmp_hdr_set1_senderKID(msg->header, ostr);
+            ASN1_OCTET_STRING_free(ostr);
+            return res;
+        }
+    }
     return id == NULL || ossl_cmp_hdr_set1_senderKID(msg->header, id);
 }
 
@@ -252,13 +269,13 @@ int ossl_cmp_msg_protect(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg)
     msg->protection = NULL;
 
     if (ctx->unprotectedSend) {
-        if (!set_senderKID(ctx, msg, NULL))
+        if (!set_senderKID(ctx, msg, ctx->referenceValue))
             goto err;
     } else if (ctx->secretValue != NULL) {
         /* use PasswordBasedMac according to 5.1.3.1 if secretValue is given */
         if ((msg->header->protectionAlg = pbmac_algor(ctx)) == NULL)
             goto err;
-        if (!set_senderKID(ctx, msg, NULL))
+        if (!set_senderKID(ctx, msg, ctx->referenceValue))
             goto err;
 
         /*

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -651,26 +651,35 @@ int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg)
     return 0;
 }
 
-static int check_transactionID_or_nonce(ASN1_OCTET_STRING *expected,
-                                        ASN1_OCTET_STRING *actual,
-                                        int reason)
+static int check_transactionID_or_nonce(OSSL_CMP_CTX *ctx, ASN1_OCTET_STRING *expected,
+                                        ASN1_OCTET_STRING *actual, int bodytype, int reason)
 {
     if (expected != NULL
         && (actual == NULL || ASN1_OCTET_STRING_cmp(expected, actual) != 0)) {
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-        char *expected_str, *actual_str;
+        char *expected_str = i2s_ASN1_OCTET_STRING(NULL, expected);
+        char *actual_str = actual == NULL ? NULL: i2s_ASN1_OCTET_STRING(NULL, actual);
+        int strict = !ctx->nonmatchedErrorNonces;
+        int res = 0;
 
-        expected_str = i2s_ASN1_OCTET_STRING(NULL, expected);
-        actual_str = actual == NULL ? NULL: i2s_ASN1_OCTET_STRING(NULL, actual);
-
-        ERR_raise_data(ERR_LIB_CMP, reason,
-                       "expected = %s, actual = %s",
-                       expected_str == NULL ? "?" : expected_str,
-                       actual == NULL ? "(none)" :
-                       actual_str == NULL ? "?" : actual_str);
+        if (reason == 0) /* just check; used for end_of_polling */
+            return res;
+        if (bodytype != OSSL_CMP_PKIBODY_ERROR)
+            strict = 1;
+        if (strict) {
+            ERR_raise_data(ERR_LIB_CMP, reason,
+                           "expected = %s, actual = %s",
+                           expected_str == NULL ? "?" : expected_str,
+                           actual == NULL ? "(none)" :
+                           actual_str == NULL ? "?" : actual_str);
+        } else {
+            ossl_cmp_log1(WARN, ctx, "ignoring missing or non-matching %s of error message",
+                          reason == CMP_R_TRANSACTIONID_UNMATCHED ? "transactionID" : "recipNonce");
+            res = 1;
+        }
         OPENSSL_free(expected_str);
         OPENSSL_free(actual_str);
-        return 0;
+        return res;
 #endif
     }
     return 1;
@@ -701,11 +710,13 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
 {
     OSSL_CMP_PKIHEADER *hdr;
     const X509_NAME *expected_sender;
+    int bodytype, end_of_polling;
     int num_untrusted, num_added, res;
 
     if (!ossl_assert(ctx != NULL && msg != NULL && msg->header != NULL))
         return 0;
     hdr = OSSL_CMP_MSG_get0_header(msg);
+    bodytype = OSSL_CMP_MSG_get_bodytype(msg);
 
     /* If expected_sender is given, validate sender name of received msg */
     expected_sender = ctx->expected_sender;
@@ -734,6 +745,8 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
             return 0;
         }
     }
+
+    /* Ignoring recipient */
     /* Note: if recipient was NULL-DN it could be learned here if needed */
 
     num_added = sk_X509_num(msg->extraCerts);
@@ -795,7 +808,7 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
 #endif
     }
 
-    if (OSSL_CMP_MSG_get_bodytype(msg) < 0) {
+    if (bodytype < 0) {
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         ERR_raise(ERR_LIB_CMP, CMP_R_PKIBODY_ERROR);
         return 0;
@@ -803,30 +816,21 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
     }
 
     /* compare received transactionID with the expected one in previous msg */
-    if (!check_transactionID_or_nonce(ctx->transactionID, hdr->transactionID,
-                                      CMP_R_TRANSACTIONID_UNMATCHED))
+    if (!check_transactionID_or_nonce(ctx, ctx->transactionID, hdr->transactionID,
+                                      bodytype, CMP_R_TRANSACTIONID_UNMATCHED))
         return 0;
 
-    /*
-     * enable clearing irrelevant errors
-     * in attempts to validate recipient nonce in case of delayed delivery.
-     */
-    (void)ERR_set_mark();
     /* compare received nonce with the one we sent */
-    if (!check_transactionID_or_nonce(ctx->senderNonce, hdr->recipNonce,
-                                      CMP_R_RECIPNONCE_UNMATCHED)) {
-        /* check if we are polling and received final response */
-        if (ctx->first_senderNonce == NULL
-            || OSSL_CMP_MSG_get_bodytype(msg) == OSSL_CMP_PKIBODY_POLLREP
-            /* compare received nonce with our sender nonce at poll start */
-            || !check_transactionID_or_nonce(ctx->first_senderNonce,
-                                             hdr->recipNonce,
-                                             CMP_R_RECIPNONCE_UNMATCHED)) {
-            (void)ERR_clear_last_mark();
+    end_of_polling = /* check if we are polling and received final response */
+        ctx->first_senderNonce != NULL && bodytype != OSSL_CMP_PKIBODY_POLLREP;
+    if (!check_transactionID_or_nonce(ctx, ctx->senderNonce, hdr->recipNonce,
+                                      bodytype, end_of_polling ? 0 : CMP_R_RECIPNONCE_UNMATCHED)) {
+        if (!end_of_polling
+            /* otherwise, compare received nonce with our sender nonce at poll start: */
+            || !check_transactionID_or_nonce(ctx, ctx->first_senderNonce, hdr->recipNonce,
+                                             bodytype, CMP_R_RECIPNONCE_UNMATCHED))
             return 0;
-        }
     }
-    (void)ERR_pop_to_mark();
 
     /* if not yet present, learn transactionID */
     if (ctx->transactionID == NULL
@@ -848,7 +852,7 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
          * the caPubs field may be directly trusted as a root CA
          * certificate by the initiator.'
          */
-        switch (OSSL_CMP_MSG_get_bodytype(msg)) {
+        switch (bodytype) {
         case OSSL_CMP_PKIBODY_IP:
         case OSSL_CMP_PKIBODY_CP:
         case OSSL_CMP_PKIBODY_KUP:

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -92,6 +92,7 @@ Server authentication options:
 [B<-expect_sender> I<name>]
 [B<-ignore_keyusage>]
 [B<-unprotected_errors>]
+[B<-nonmatched_error_nonces>]
 [B<-no_cache_extracerts>]
 [B<-srvcertout> I<filename>]
 [B<-extracertsout> I<filename>]
@@ -680,6 +681,12 @@ This option applies to both CMP clients and the mock server.
 
 Accept missing or invalid protection of negative responses from the server.
 This applies to the following message types and contents:
+
+=item B<-nonmatched_error_nonces>
+
+Accept missing or non-matching transactionID or recipNonce values in error messages.
+This can be helpful in case the server cannot provide a proper error message,
+for instance if was unable to parse the ASN.1 encoding of a request message.
 
 =item B<-no_cache_extracerts>
 

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -773,9 +773,11 @@ Default is C<pem>.
 
 =item B<-ref> I<value>
 
-Reference number/string/value to use as fallback senderKID; this is required
-if no sender name can be determined from the B<-cert> or <-subject> options and
-is typically used when authenticating with pre-shared key (password-based MAC).
+Reference string/name value to place in senderKID when using MAC-based protection.
+When not provided, the commonName of the sender field is taken as the fallback value.
+Conversely, when provided, the value is also taken as the commonName
+of the sender field when using of MAC-based protection,
+while for signature-base protection it is just taken as the ultimate fallback value.
 
 =item B<-secret> I<arg>
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -316,6 +316,12 @@ B<WARNING:> This setting leads to unspecified behavior and it is meant
 exclusively to allow interoperability with server implementations violating
 RFC 4210.
 
+=item B<OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES>
+
+        Accept missing or non-matching transactionID or recipNonce in error messages.
+        This can be helpful in case the server cannot provide a proper error message,
+        for instance if was unable to parse the ASN.1 encoding of a request message.
+
 =item B<OSSL_CMP_OPT_IGNORE_KEYUSAGE>
 
         Ignore key usage restrictions in the signer's certificate when

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -481,9 +481,11 @@ When using signature-based protection of CMP request messages
 this CMP signer certificate will be included first in the extraCerts field.
 It serves as fallback reference certificate, see OSSL_CMP_CTX_set1_oldCert().
 The subject of this I<cert> will be used as the sender field of outgoing
-messages, while the subject of any cert set via OSSL_CMP_CTX_set1_oldCert(),
+messages, while fallback values are
+the subject of any cert set via OSSL_CMP_CTX_set1_oldCert(),
 the subject of any PKCS#10 CSR set via OSSL_CMP_CTX_set1_p10CSR(),
-and any value set via OSSL_CMP_CTX_set1_subjectName() are used as fallback.
+any value set via OSSL_CMP_CTX_set1_subjectName(), or else any value provided via
+OSSL_CMP_CTX_set1_referenceValue() and used as the commonName in a DN structure.
 
 The I<cert> argument may be NULL to clear the entry.
 
@@ -517,11 +519,18 @@ PBM-based protection takes precedence over signature-based protection.
 
 OSSL_CMP_CTX_set1_referenceValue() sets the given referenceValue I<ref> with
 length I<len> in the given I<ctx> or clears it if the I<ref> argument is NULL.
-According to RFC 4210 section 5.1.1, if no value for the sender field in
-CMP message headers can be determined (i.e., no CMP signer certificate
+When provided, the value is placed in senderKID when using MAC-based protection.
+When not provided, the commonName of the sender field is taken as the fallback value.
+Conversely, when provided, the value is also taken as the commonName of the sender
+field when using of MAC-based protection (as specified in RFC 9483 section 3.1),
+while for signature-base protection it is just taken as the ultimate fallback value.
+According to RFC 4210 section 5.1.1, if no value for the sender field in CMP message
+headers can be determined then the sender field will contain the NULL-DN.
+This can only happen if there is no CMP signer certificate, no certificate to be
+updated, and no PKCS#10 CSR is available from which the subject name could be taken
 and no subject DN is set via OSSL_CMP_CTX_set1_subjectName()
-then the sender field will contain the NULL-DN
-and the senderKID field of the CMP message header must be set.
+and no reference value is set via OSSL_CMP_CTX_set1_referenceValue().
+
 When signature-based protection is used the senderKID will be set to
 the subjectKeyIdentifier of the CMP signer certificate as far as present.
 If not present or when PBM-based protection is used
@@ -613,6 +622,8 @@ OSSL_CMP_CTX_set1_p10CSR() sets the PKCS#10 CSR to use in P10CR messages.
 If such a CSR is provided, its subject and public key fields are also
 used as fallback values for the certificate template of IR/CR/KUR/RR messages,
 and any extensions included are added to the template of IR/CR/KUR messages.
+Its subject is also used as fallback sender value in CMP message headers if neither
+OSSL_CMP_CTX_set1_cert() nor OSSL_CMP_CTX_set1_oldCert() have been used.
 
 OSSL_CMP_CTX_push0_genm_ITAV() adds I<itav> to the stack in the I<ctx> which
 will be the body of a General Message sent with this context.

--- a/include/cmp/openssl/cmp.h
+++ b/include/cmp/openssl/cmp.h
@@ -200,6 +200,7 @@ typedef ASN1_BIT_STRING OSSL_CMP_PKIFAILUREINFO;
  *       -- CertReqMsg
  *   }
  */
+#  define OSSL_CMP_PKISTATUS_rejection_by_client    -4
 #  define OSSL_CMP_PKISTATUS_request                -3
 #  define OSSL_CMP_PKISTATUS_trans                  -2
 #  define OSSL_CMP_PKISTATUS_unspecified            -1

--- a/include/cmp/openssl/cmp.h
+++ b/include/cmp/openssl/cmp.h
@@ -511,6 +511,7 @@ const char *OSSL_CMP_CTX_get0_propq(const OSSL_CMP_CTX *ctx);
 #  define OSSL_CMP_OPT_IGNORE_KEYUSAGE 35
 #  define OSSL_CMP_OPT_PERMIT_TA_IN_EXTRACERTS_FOR_IR 36
 #  define OSSL_CMP_OPT_NO_CACHE_EXTRACERTS 37
+#  define OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES 38
 int OSSL_CMP_CTX_set_option(OSSL_CMP_CTX *ctx, int opt, int val);
 int OSSL_CMP_CTX_get_option(const OSSL_CMP_CTX *ctx, int opt);
 /* CMP-specific callback for logging and outputting the error queue: */

--- a/include/cmp/openssl/cmp.h.in
+++ b/include/cmp/openssl/cmp.h.in
@@ -196,6 +196,7 @@ typedef ASN1_BIT_STRING OSSL_CMP_PKIFAILUREINFO;
  *       -- CertReqMsg
  *   }
  */
+#  define OSSL_CMP_PKISTATUS_rejection_by_client    -4
 #  define OSSL_CMP_PKISTATUS_request                -3
 #  define OSSL_CMP_PKISTATUS_trans                  -2
 #  define OSSL_CMP_PKISTATUS_unspecified            -1

--- a/include/cmp/openssl/cmp.h.in
+++ b/include/cmp/openssl/cmp.h.in
@@ -294,6 +294,7 @@ const char *OSSL_CMP_CTX_get0_propq(const OSSL_CMP_CTX *ctx);
 #  define OSSL_CMP_OPT_IGNORE_KEYUSAGE 35
 #  define OSSL_CMP_OPT_PERMIT_TA_IN_EXTRACERTS_FOR_IR 36
 #  define OSSL_CMP_OPT_NO_CACHE_EXTRACERTS 37
+#  define OSSL_CMP_OPT_NONMATCHED_ERROR_NONCES 38
 int OSSL_CMP_CTX_set_option(OSSL_CMP_CTX *ctx, int opt, int val);
 int OSSL_CMP_CTX_get_option(const OSSL_CMP_CTX *ctx, int opt);
 /* CMP-specific callback for logging and outputting the error queue: */


### PR DESCRIPTION
* cmp_ctx.c OSSL_CMP_CTX_new(): update and/or comment the default PBM parameters chosen
* cmp_hdr.c ossl_cmp_hdr_init() and cmp_protect.c set_senderKID(): fix default sender and senderKID
* cmp_client.c cert_response(): fix diagnostics on rejecting newly enrolled certificate
* add option for accepting missing or non-matching transactionID or recipNonce in error message

The latter is useful  in case the server cannot provide a proper error message,
for instance when if was not able to parse the ASN.1 encoding of a request message.
This results for instance in the following output:
```
cmpClient:send_receive_check():crypto/cmp/cmp_client.c:205: INFO: received ERROR
cmpClient:unprotected_exception():crypto/cmp/cmp_client.c:84: WARNING: ignoring missing protection of error response
cmpClient:check_transactionID_or_nonce():crypto/cmp/cmp_vfy.c:677: WARNING: ignoring missing or non-matched transactionID of error message
cmpClient:check_transactionID_or_nonce():crypto/cmp/cmp_vfy.c:677: WARNING: ignoring missing or non-matched recipNonce of error message
cmpClient:CMPclient():src/cmpClient.c:2429: ERROR: received from pki.certificate.fi:8700/pkix/ PKIStatus: rejection; PKIFailureInfo: badDataFormat; StatusString: "ASN.1 decoding error"
cmpClient:CMPclient():src/cmpClient.c:2445: ERROR: Failed to perform CMP transaction
cmpClient:send_receive_check():crypto/cmp/cmp_client.c:231: ERROR: received error:PKIStatus: rejection; PKIFailureInfo: badDataFormat; StatusString: "ASN.1 decoding error"
cmpClient:CMPclient():src/cmpClient.c:2488: ERROR: CMPclient error 180: received error
```